### PR TITLE
Accumulated loading

### DIFF
--- a/R/api_dataframe_reader.R
+++ b/R/api_dataframe_reader.R
@@ -31,8 +31,24 @@ DataReader = R6::R6Class(classname = 'DataReader',
                            },
                            get_data = function(){
                              private$.data_df
-                           }
+                           },
                            # get_pipeline_df = function() { private$.pipeline_df }
+                           verify_read = function() {
+                             if( ! ('biosample_name' %in% colnames(private$.data_df)) ) {
+                               stop("Column `biosample_name` must be introduced (if not already present) by DataReader")
+                             }
+                             if ( any(
+                                    sapply(
+                                      c('__DNA', '__RNA', '__Protein'), 
+                                      function(suffix) {length(grep(suffix, private$.data_df$biosample_name)) > 1}
+                                      )
+                                    )
+                                  ) {
+                               stop("`sample_molecule_type` should not be present in column `biosample_name`")
+                             }
+                             
+                             
+                           }
                          ),
                          private = list(
                            .measurement_set = NULL,

--- a/R/api_dataframe_reader.R
+++ b/R/api_dataframe_reader.R
@@ -765,6 +765,17 @@ DataReaderFusionDeFuse = R6::R6Class(
      private$.data_df$num_spanning_reads = NA
      private$.data_df$num_mate_pairs = NA
      private$.data_df$num_mate_pairs_fusion = NA
+     
+     if (nrow(private$.data_df) == 0) {
+       private$.data_df$biosample_name = character()
+     } else {
+       if (length(unique(private$.pipeline_df$original_sample_name)) > 1) {
+         stop("Expected per sample file for this reader")
+       }
+       if (!('biosample_name' %in% colnames(private$.data_df))) {
+        private$.data_df$biosample_name = private$.pipeline_df$original_sample_name
+       }
+     }
    }
   ))
 


### PR DESCRIPTION
When reading multiple per sample files, start accumulating DataReader output if the output is very small per file.

This assumes that the DataReader object stores the data read from a file in an R data frame (one exception is ExomicVariant data when the DataReader object stores data in a vcfR object -- but that can be handled separately). 

Another addition is the `verify_read()` method in the DataReader class -- this adds some constraints to the data-frames formulated by DataReader object e.g. `biosample_name` must be present always.   