### PR TITLE
stop caching biosamples and relying on cached biosamples

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -178,18 +178,6 @@ search_entity = function(entity, id, ...){
   }
 }
 
-get_biosamples_from_cache = function(updateCache = FALSE, con = NULL){
-  if (updateCache | is.null(.ghEnv$cache$biosample_ref)){
-    update_biosample_cache(con = con)
-  }
-  return(.ghEnv$cache$biosample_ref)
-}
-
-update_biosample_cache = function(con = NULL){
-  con = use_ghEnv_if_null(con)
-  .ghEnv$cache$biosample_ref = get_biosamples(con = con)
-}
-
 #' @export
 get_ontology = function(ontology_id = NULL, updateCache = FALSE, con = NULL){
   get_ontology_from_cache(ontology_id = ontology_id, 

--- a/R/package.R
+++ b/R/package.R
@@ -59,7 +59,6 @@ NULL
 
 # Prepare variables for the cache
 .ghEnv$cache$lookup = list()
-.ghEnv$cache$biosample_ref = NULL
 .ghEnv$cache[[.ghEnv$meta$arrOntology]] = NULL
 .ghEnv$cache[[.ghEnv$meta$arrVariantKey]] = NULL
 .ghEnv$cache[[.ghEnv$meta$arrDefinition]] = NULL

--- a/R/search.R
+++ b/R/search.R
@@ -438,14 +438,8 @@ search_expression = function(measurementset = NULL,
     # If user did not provide biosample, then query the server for it, or retrieve from global biosample list
     if (is.null(biosample)) {
       biosample_id = unique(res$biosample_id)
-      if (FALSE) { # avoiding this path right now (might be useful when the download of all accessible biosamples is prohibitive)
-        cat("query the server for matching biosamples\n")
-        biosample = get_biosamples(biosample_id, con = con)
-      } else{
-        biosample_ref = get_biosamples_from_cache(con = con)
-        biosample = biosample_ref[biosample_ref$biosample_id %in% biosample_id, ]
-        biosample = drop_na_columns(biosample)
-      }
+      cat("query the server for matching biosamples\n")
+      biosample = get_biosamples(biosample_id, con = con)
     }
     
     # If user did not provide feature, then query the server for it, or retrieve from global feature list

--- a/tests_custom/api_dataframe_tests.R
+++ b/tests_custom/api_dataframe_tests.R
@@ -1,5 +1,5 @@
 reference_object = list(biosample_ref = data.frame(name = c('a', 'b', 'c'),
-                                                   bioample_id = 132:134,
+                                                   biosample_id = 132:134,
                                                    stringsAsFactors = FALSE),
                         feature_ref = data.frame(name = c('EGFR', 'MYC', 'P53'),
                                                  feature_id = 2062:2064,


### PR DESCRIPTION
- when required, download biosamples using `get_biosamples(biosample_id = c(1:3, 101, ...))` call

This is required because downloading all biosamples and caching them is becoming prohibitively expensive 

e.g. at deployment A

```R
system.time({b = get_biosamples()})
#     user  system elapsed 
#  23.946   1.266  25.733 
format(object.size(b), units="Mb")
# [1] "237.5 Mb"
```

whereas downloading a set of biosamples is much faster

```R
# Random set of 1000 samples
system.time({b = get_biosamples(biosample_id = sample(c(1:max(b$biosample_id)), size = 1000))})
# 1.111 

# Contiguous set of 1001 biosamples
system.time({b = get_biosamples(biosample_id = 3400:3500)})
# 0.223
```