### PR TITLE
Optimizations to `get_features`

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -749,6 +749,7 @@ get_features = function(feature_id = NULL, mandatory_fields_only = FALSE, con = 
           return = T)
         ftr_info = drop_equi_join_dims(ftr_info)
         ftr_info = ftr_info[, c('feature_id', 'key', 'val')]
+        ftr_info = ftr_info[!is.na(ftr_info$val) & ftr_info$val != "" & ftr_info$val != "NA", ]
         # Following extracted from `unpivot_key_value_pairs()`
         x2t = spread(ftr_info, "key", value = "val")
         x2t = x2t[, which(!(colnames(x2t) == "<NA>"))]
@@ -766,6 +767,7 @@ get_features = function(feature_id = NULL, mandatory_fields_only = FALSE, con = 
     if (!mandatory_fields_only) {
       ftr_info = iquery(con$db, paste(qq, "_INFO", sep=""), return = T)
       ftr_info = ftr_info[, c('feature_id', 'key', 'val')]
+      ftr_info = ftr_info[!is.na(ftr_info$val) & ftr_info$val != "" & ftr_info$val != "NA", ]
       ftr_info = spread(ftr_info, "key", value = "val")
       result = merge(result, ftr_info, by = get_base_idname(arrayname), all.x = T)
     }

--- a/R/functions.R
+++ b/R/functions.R
@@ -560,7 +560,8 @@ select_from_1d_entity = function(entitynm, id, dataset_version = NULL,
     if (length(get_idname(entitynm)) == 1) {
       qq = form_selector_query_1d_array(arrayname = fullnm,
                                         idname = get_base_idname(fullnm),
-                                        selected_ids = id)
+                                        selected_ids = id,
+                                        join_algorithm = 'cross_join')
     } else {
       qq = form_selector_query_secure_array(arrayname = fullnm,
                                             selected_ids = id,
@@ -717,7 +718,8 @@ get_features = function(feature_id = NULL, mandatory_fields_only = FALSE, con = 
   
   qq = arrayname
   if (!is.null(feature_id)) {
-    qq = form_selector_query_1d_array(arrayname, get_base_idname(arrayname), as.integer(feature_id))
+    qq = form_selector_query_1d_array(arrayname, get_base_idname(arrayname), as.integer(feature_id),
+                                      join_algorithm = 'equi_join')
     
     # URL length restriction enforce by apache (see https://github.com/Paradigm4/<CUSTOMER>/issues/53)
     THRESH_query_len = 270000 # as set in /opt/rh/httpd24/root/etc/httpd/conf.d/25-default_ssl.conf


### PR DESCRIPTION
Added multiple optimizations to speed up `get_features`

For downloading all features
- skip empty values in `FEATURE_INFO` array
- introduce faster method of merging data.frames based on one column

Allow user flexibility to choose different join algorithms for different selection query  …
- `cross_join` for metadata (the previous usage)
- `equi_join` for features (new usage; this was found to be faster when downloading a large set of features -- e.g. using a build literal)